### PR TITLE
fix tab complete weird behavior

### DIFF
--- a/minestom/src/main/java/me/lucko/luckperms/minestom/MinestomCommandExecutor.java
+++ b/minestom/src/main/java/me/lucko/luckperms/minestom/MinestomCommandExecutor.java
@@ -66,8 +66,9 @@ public class MinestomCommandExecutor extends CommandManager {
 
             params.setSuggestionCallback((sender, context, suggestion) -> {
                 Sender wrapped = this.commandExecutor.plugin.getSenderFactory().wrap(sender);
-                String[] args = context.get(params);
-                if (args == null) args = new String[0];
+                String input = context.getInput();
+                String[] split = input.split(" ", 2);
+                String args = split.length > 1 ? split[1] : "";
                 List<String> arguments = ArgumentTokenizer.TAB_COMPLETE.tokenizeInput(args);
                 tabCompleteCommand(wrapped, arguments).stream().map(SuggestionEntry::new).forEach(suggestion::addEntry);
             });


### PR DESCRIPTION
since we use an argument for all the input, we can use getInput that gives a better raw data than the context getRaw (which misses an end space if it exists)